### PR TITLE
Self labeling on posts

### DIFF
--- a/app/components/PostView.vue
+++ b/app/components/PostView.vue
@@ -11,7 +11,7 @@
               rounded
               :img="props.avatar_url"
               :alt="props.handle"
-              class="mr-3 min-w-max" />
+              class="min-w-max" />
           </a>
         </div>
         <div class="truncate">

--- a/app/components/PostView.vue
+++ b/app/components/PostView.vue
@@ -71,13 +71,17 @@
           v-if="props.post.value.reply"
           :aturi="props.post.value.reply.parent.uri"
           class="inline-block font-light text-xs text-gray-600 hover:text-white border border-gray-700 hover:bg-gray-800 focus:ring-2 focus:outline-none focus:ring-blue-300 rounded-lg px-3 py-1 text-center mr-1 mb-1 dark:border-slate-500 dark:text-slate-500 dark:hover:text-white dark:hover:bg-slate-500 dark:focus:ring-slate-800">
-          <font-awesome-icon :icon="['fas', 'reply']" />
+          <FontAwesomeIcon :icon="['fas', 'reply']" />
           Reply
         </AtHandleLink>
       </div>
       <!-- Post message -->
       <div v-if="!props.removed" class="break-words whitespace-pre-line">
-        {{ props.post.value.text }}
+        <div class="text-sm">
+
+          <!-- <RitchText :post="props.post" /> -->
+          {{ props.post.value.text }}
+        </div>
       </div>
       <div v-else class="italic">This post may have been removed.</div>
       <div v-if="!props.removed && props.post.value.embed">
@@ -86,7 +90,28 @@
       </div>
     </div>
 
-    <div class="flex justify-end">
+    <div class="flex justify-end items-end">
+      <div v-if="!props.removed" class="mt-3 inline-box">
+        <!-- Labels -->
+        <ul v-if="props.post.value.labels?.values" class="inline-block">
+          <li
+            v-if="props.post.value.labels?.values.length > 0"
+            v-for="(label, index) in props.post.value.labels?.values"
+            :key="index"
+            class="inline-block items-center px-1 py-0.5 mr-2 text-xs font-medium rounded"
+            :class="
+            label.val === '!warn'
+            ? `text-yellow-800 bg-yellow-100 dark:bg-yellow-900 dark:text-yellow-300`
+            : label.val === 'porn' || label.val === 'nsfw'
+            ? `text-pink-500 bg-pink-100 dark:bg-pink-700 dark:text-pink-300`
+            : label.val === 'spam'
+            ? `text-zinc-800 bg-zinc-100 dark:bg-zin-900 dark:text-zinc-300`
+            : `text-indigo-800 bg-indigo-100 dark:bg-indigo-900 dark:text-indigo-300`
+            ">
+              <FontAwesomeIcon :icon="['fas', 'tag']" class="mr-1" size="xs" />{{ label.val }}
+          </li>
+        </ul>
+      </div>
       <div
         v-if="!props.removed && props.post.value.langs"
         class="justify-start items-baseline text-xs text-right text-gray-400 dark:text-gray-700">
@@ -102,6 +127,7 @@
   import { DateTime } from 'luxon'
   import { useAppConfig } from 'nuxt/app'
   import * as lexicons from '@/utils/lexicons'
+  import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
   const config = useAppConfig()
 

--- a/app/components/UserField.vue
+++ b/app/components/UserField.vue
@@ -3,14 +3,14 @@
     <div class="flex justify-between items-center mb-2">
       <div class="flex items-center">
         <div
-          class="inline-flex items-center mr-1 text-md font-bold text-gray-900 dark:text-white">
+          class="inline-flex items-center mr-3 text-md font-bold text-gray-900 dark:text-white">
           <!-- Avatar -->
           <a :href="`/profile/${props.handle}`" @click.prevent="clickProfile">
             <Avatar
               rounded
               :img="avatarURL"
               :alt="props.handle"
-              class="mr-2 min-w-max" />
+              class="min-w-max" />
           </a>
         </div>
         <div class="max-w-xs truncate">


### PR DESCRIPTION
# Summary

- User can specify self-label to each their posts while new posting.
- This can be pre-specified for NSFW content, spoiler warnings, etc.
- **In this case, if the post contains a label, it is only displayed.**
- The client sees the label and changes the display appropriately.
- However, the label can currently be specified as an arbitrary 128-byte word, so the response may vary from client to client.