### PR TITLE
Update SkyTools brand colors in headers

### DIFF
--- a/app/components/NavLink.vue
+++ b/app/components/NavLink.vue
@@ -26,6 +26,7 @@
 
 <script setup>
   import { defineProps } from 'vue'
+  import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
   const props = defineProps({
     href: {

--- a/app/components/Navbar.vue
+++ b/app/components/Navbar.vue
@@ -7,7 +7,7 @@
         <!-- Logo -->
         <NuxtLink to="/" class="flex items-center">
           <span
-            class="self-center text-2xl text-transparent bg-clip-text bg-gradient-to-b to-blue-700 from-green-300 dark:to-orange-500 dark:from-sky-300 font-semibold whitespace-nowrap dark:text-sky">
+            class="self-center text-2xl text-transparent bg-clip-text bg-gradient-to-b to-sky-400 to-80% from-green-300 from-20% via-60% via-sky-600 dark:from-30% dark:via-rose-400 dark:via-50% dark:to-yellow-400 dark:from-blue-500 font-semibold whitespace-nowrap dark:text-sky">
             {{ appName }}
           </span>
         </NuxtLink>

--- a/app/pages/history.vue
+++ b/app/pages/history.vue
@@ -91,6 +91,7 @@
     useRouter,
   } from '#imports'
   import axios from 'axios'
+  import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
   const route = useRoute()
   const router = useRouter()

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -62,6 +62,7 @@
 
 <script setup lang="ts">
   import { useAppConfig, useSeoMeta } from '#imports'
+  import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
   const config = useAppConfig()
   const appName = config.title

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+version: "1.0"
+
+#Specify inspection profile for code analysis
+profile:
+  name: com.anon5r.skytools
+
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
+
+#Specify Qodana linter for analysis (Applied in CI/CD pipeline)
+linter: jetbrains/qodana-js:latest


### PR DESCRIPTION
# Overview

Changed the color of the SkyTools text in the upper left.

# Why changes

When viewed in dark mode, it is an image of the evening sky.
The color of the sky that was actually shared by a Bluesky user was beautiful, so I used that as a reference.

<img width="127" alt="ScreenShot 2024-01-12 0 56 32" src="https://github.com/anon5r/SkyTools/assets/66147/62938c15-ec64-4ca4-b5f9-ad3088b8c5eb">

At the same time, we also slightly changed the hue in light mode.
<img width="130" alt="ScreenShot 2024-01-12 0 56 49" src="https://github.com/anon5r/SkyTools/assets/66147/993f22e0-6118-41a1-aa0b-d666a7a9af20">


[The photo in this post](https://bsky.app/profile/takubows.com/post/3kiow6zf2r42f)
![image](https://github.com/anon5r/SkyTools/assets/66147/6b87b50e-1aa3-4e98-b0e6-f0f5547a8629)
