### PR TITLE
Fix could not update profile if handle is invalid

### DIFF
--- a/app/pages/self/profile.vue
+++ b/app/pages/self/profile.vue
@@ -403,7 +403,7 @@
         val: label,
       }))
       const update = {
-        repo: profile.value.handle,
+        repo: profile.value.did,
         did: profile.value.did,
         collection: 'app.bsky.actor.profile',
         record: {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -11294,11 +11294,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.3.3#~builtin<compat/typescript>":
   version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=e012d7"
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 4e604a9e107ce0c23b16a2f8d79d0531d4d8fe9ebbb7a8c395c66998c39892f0e0a071ef0b0d4e66420a8ec2b8d6cfd9cdb29ba24f25b37cba072e9282376df9
+  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What happens

Could not update profile while the handle is invalid

# Why is this happening?

The repository name for the profile was being sent in the handle. In this case, it is sent as handle.invalid, so it cannot be updated.

# How to solve

Changed to specify DID as repository and send instead of handle.
